### PR TITLE
Simplification 1: `index.md`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,16 +186,15 @@
     "haskell-flake_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1707500634,
+        "lastModified": 1707501052,
         "narHash": "sha256-gjZ9Q1IK5AupIDT5FAVZ3b1OK7nyOtWzkNdQIqwTF4Q=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "6050a58d5cb17c9b7141e6ae347a65d86964d169",
+        "rev": "c5b36777ba5edcc6bc25719fb82e7b9090f311b6",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "index-notes",
         "repo": "haskell-flake",
         "type": "github"
       }
@@ -238,16 +237,15 @@
     "mission-control": {
       "flake": false,
       "locked": {
-        "lastModified": 1707499936,
+        "lastModified": 1707501043,
         "narHash": "sha256-S3e8pfjXT335TuacspMyPbMnRX5c+qhvN4Jbm/R+3HM=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "a4c09d769afc8ec77b9c4a355a5c5f8ff087146d",
+        "rev": "c275dd195776b1b9735790231d874a3c5a7ee779",
         "type": "github"
       },
       "original": {
         "owner": "Platonic-Systems",
-        "ref": "index-notes",
         "repo": "mission-control",
         "type": "github"
       }
@@ -255,16 +253,15 @@
     "nixos-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1707499770,
+        "lastModified": 1707501063,
         "narHash": "sha256-7CINolspTZ/pcj2o/Um7A1wrpa7Irt6Nhxwqw4gOHWE=",
         "owner": "srid",
         "repo": "nixos-flake",
-        "rev": "8c28578b9f38a4f0febc0856e6581a8bef91ff3b",
+        "rev": "3891b2030114f8661402991eac9be0ed59f786ae",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "index-notes",
         "repo": "nixos-flake",
         "type": "github"
       }
@@ -322,16 +319,15 @@
     "process-compose-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1707499903,
+        "lastModified": 1707501022,
         "narHash": "sha256-vFpBhezqEd6WwcFya0zH2zCGYNoH2hwPRFJQ4SYPLc4=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "16541caa5f46ac575f30c209fcaa4bd2e814912a",
+        "rev": "b346fb30ad5fdee14e3edc3ba490eaa5db9ec0b7",
         "type": "github"
       },
       "original": {
         "owner": "Platonic-Systems",
-        "ref": "index-notes",
         "repo": "process-compose-flake",
         "type": "github"
       }
@@ -358,16 +354,15 @@
     "services-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1707499857,
+        "lastModified": 1707501073,
         "narHash": "sha256-yAb2h9oaDjVcYTZn0PghijYQxV3izQ7qAEGgpj/KX0E=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "5a3fb8089c297b65ced6682115ea5003ebd4bd7e",
+        "rev": "9411399310e46afe8e6bae675b414503840e71eb",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
-        "ref": "index-notes",
         "repo": "services-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -186,11 +186,11 @@
     "haskell-flake_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1707494051,
-        "narHash": "sha256-t+7GGjBej3hPnGm0MzGkoiq1PQKL4GJ0TXrvp2LRHEk=",
+        "lastModified": 1707500634,
+        "narHash": "sha256-gjZ9Q1IK5AupIDT5FAVZ3b1OK7nyOtWzkNdQIqwTF4Q=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "cecf537b87b044c561be719c89e720cbb6f55876",
+        "rev": "6050a58d5cb17c9b7141e6ae347a65d86964d169",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -85,15 +85,16 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1707492649,
-        "narHash": "sha256-CxW8dw/knjI1k1deF9c1QkFCkvn1QCc8JzEmcnluFH0=",
+        "lastModified": 1707494564,
+        "narHash": "sha256-6HosmTYdFV1wREg0fdNeqTxTC/B7Av/ROznCJzYeW9c=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "9849d42910bfc1a52acae4e3e93e7588811edb3c",
+        "rev": "b2f566b4051683c26924b8f332f06aab9a162d4c",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "index-notes",
         "repo": "emanote",
         "type": "github"
       }
@@ -185,15 +186,16 @@
     "haskell-flake_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1707242163,
-        "narHash": "sha256-w+cBynh7yqnpVtFdu1SEZxPgtlz/nWnv47D5crnPXHM=",
+        "lastModified": 1707494051,
+        "narHash": "sha256-t+7GGjBej3hPnGm0MzGkoiq1PQKL4GJ0TXrvp2LRHEk=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "f9d17c3aa68e65529f424816c8b9346ae602d1de",
+        "rev": "cecf537b87b044c561be719c89e720cbb6f55876",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "index-notes",
         "repo": "haskell-flake",
         "type": "github"
       }
@@ -236,15 +238,16 @@
     "mission-control": {
       "flake": false,
       "locked": {
-        "lastModified": 1705982654,
-        "narHash": "sha256-7MvdCF0dxK8FRbBQXCC9JTuEh/7i5TAA1iU/8RNW/lI=",
+        "lastModified": 1707499936,
+        "narHash": "sha256-S3e8pfjXT335TuacspMyPbMnRX5c+qhvN4Jbm/R+3HM=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "7aff11c21bd7b2045fdd90e6d0a1c714e96020d4",
+        "rev": "a4c09d769afc8ec77b9c4a355a5c5f8ff087146d",
         "type": "github"
       },
       "original": {
         "owner": "Platonic-Systems",
+        "ref": "index-notes",
         "repo": "mission-control",
         "type": "github"
       }
@@ -252,15 +255,16 @@
     "nixos-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1705990839,
-        "narHash": "sha256-Gb0bvp7BiHBn2PkssT4CiBhD7lVWqSHEBfiai/RFfSQ=",
+        "lastModified": 1707499770,
+        "narHash": "sha256-7CINolspTZ/pcj2o/Um7A1wrpa7Irt6Nhxwqw4gOHWE=",
         "owner": "srid",
         "repo": "nixos-flake",
-        "rev": "244072b1f9088833627046d703d7973b90fe7843",
+        "rev": "8c28578b9f38a4f0febc0856e6581a8bef91ff3b",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "index-notes",
         "repo": "nixos-flake",
         "type": "github"
       }
@@ -318,15 +322,16 @@
     "process-compose-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1706414413,
-        "narHash": "sha256-k56qLk1GI26Pv0HjCc0xeW1t67ADou/qLxqtPupa/B0=",
+        "lastModified": 1707499903,
+        "narHash": "sha256-vFpBhezqEd6WwcFya0zH2zCGYNoH2hwPRFJQ4SYPLc4=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "f1b453e251ad5fd7523436230146bae6f34c1229",
+        "rev": "16541caa5f46ac575f30c209fcaa4bd2e814912a",
         "type": "github"
       },
       "original": {
         "owner": "Platonic-Systems",
+        "ref": "index-notes",
         "repo": "process-compose-flake",
         "type": "github"
       }
@@ -353,15 +358,16 @@
     "services-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1707323586,
-        "narHash": "sha256-QeP05m82Tt66G632xWO2PbGpAT5UKGlpn9sm06QUNXQ=",
+        "lastModified": 1707499857,
+        "narHash": "sha256-yAb2h9oaDjVcYTZn0PghijYQxV3izQ7qAEGgpj/KX0E=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "a0bde519ed10c5dc34cba4b452583dd367e242b0",
+        "rev": "5a3fb8089c297b65ced6682115ea5003ebd4bd7e",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "index-notes",
         "repo": "services-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
       perSystem = { config, self', pkgs, lib, system, ... }:
         let
           getDocDir = moduleName:
+            # Each module gets put in its own directory, thus they get "mounted"
+            # on /${moduleName} on the generated website.
             pkgs.runCommand "${moduleName}-docs-shifted" { } ''
               mkdir -p $out/
               cp -r ${inputs.${moduleName}}/doc $out/${moduleName}

--- a/flake.nix
+++ b/flake.nix
@@ -11,15 +11,15 @@
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
 
     # Individual flake-parts modules go here
-    haskell-flake.url = "github:srid/haskell-flake/index-notes";
+    haskell-flake.url = "github:srid/haskell-flake";
     haskell-flake.flake = false;
-    nixos-flake.url = "github:srid/nixos-flake/index-notes";
+    nixos-flake.url = "github:srid/nixos-flake";
     nixos-flake.flake = false;
-    services-flake.url = "github:juspay/services-flake/index-notes";
+    services-flake.url = "github:juspay/services-flake";
     services-flake.flake = false;
-    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake/index-notes";
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     process-compose-flake.flake = false;
-    mission-control.url = "github:Platonic-Systems/mission-control/index-notes";
+    mission-control.url = "github:Platonic-Systems/mission-control";
     mission-control.flake = false;
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -5,21 +5,21 @@
   };
 
   inputs = {
-    emanote.url = "github:srid/emanote";
+    emanote.url = "github:srid/emanote/index-notes"; # https://github.com/srid/emanote/pull/512
     nixpkgs.follows = "emanote/nixpkgs";
     flake-parts.follows = "emanote/flake-parts";
 
     # Individual flake-parts modules go here
-    haskell-flake.url = "github:srid/haskell-flake";
+    haskell-flake.url = "github:srid/haskell-flake/index-notes";
     haskell-flake.flake = false;
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
-    nixos-flake.url = "github:srid/nixos-flake";
+    nixos-flake.url = "github:srid/nixos-flake/index-notes";
     nixos-flake.flake = false;
-    services-flake.url = "github:juspay/services-flake";
+    services-flake.url = "github:juspay/services-flake/index-notes";
     services-flake.flake = false;
-    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake/index-notes";
     process-compose-flake.flake = false;
-    mission-control.url = "github:Platonic-Systems/mission-control";
+    mission-control.url = "github:Platonic-Systems/mission-control/index-notes";
     mission-control.flake = false;
   };
 
@@ -43,10 +43,10 @@
       perSystem = { config, self', pkgs, lib, system, ... }:
         let
           getDocDir = moduleName:
-            lib.cleanSourceWith {
-              name = "${moduleName}-docs";
-              src = inputs.${moduleName} + /doc;
-            };
+            pkgs.runCommand "${moduleName}-docs-shifted" { } ''
+              mkdir -p $out/
+              cp -r ${inputs.${moduleName}}/doc $out/${moduleName}
+            '';
           moduleDocs = builtins.map getDocDir modules;
           modules = [
             "haskell-flake"

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,11 @@
     emanote.url = "github:srid/emanote/index-notes"; # https://github.com/srid/emanote/pull/512
     nixpkgs.follows = "emanote/nixpkgs";
     flake-parts.follows = "emanote/flake-parts";
+    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
 
     # Individual flake-parts modules go here
     haskell-flake.url = "github:srid/haskell-flake/index-notes";
     haskell-flake.flake = false;
-    hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
     nixos-flake.url = "github:srid/nixos-flake/index-notes";
     nixos-flake.flake = false;
     services-flake.url = "github:juspay/services-flake/index-notes";


### PR DESCRIPTION
Resolves this part

> 1. `haskell-flake.md` should just be `index.md` (see [Combining multiple notebooks srid/emanote#494](https://github.com/srid/emanote/issues/494)); and `haskell-flake/*.md` should all be moved to top-level

of #6 

Uses https://github.com/srid/emanote/pull/512 (see unchecked tasks for known limitation)