### PR TITLE
ci: Use the right cache to speed up builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v22
         with:
-          submodules: recursive
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v4
-      - uses: cachix/cachix-action@v14
-        with:
-          name: srid
+          extra_nix_config: |
+            trusted-public-keys = cache.srid.ca:8sQkbPrOIoXktIwI0OucQBXod2e9fDjjoEZWn8OXbdo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.srid.ca?priority=40 https://cache.nixos.org/
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build website
         run: nix build
 


### PR DESCRIPTION
Otherwise, Emanote will compile on every commit to `main`.