### PR TITLE
index: link to nixos.asia tutorials

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -5,6 +5,6 @@ emanote:
 
 # community.flake.parts
 
-This is a place to document the various [[mods|flake modules]]# created using [flake-parts](https://flake.parts/).
+This is a place to document the various [[mods|flake modules]]# created using [flake-parts](https://flake.parts/). See [NixOS Asia](https://nixos.asia/en/nix-tutorial) for general tutorials on Nix and the module system itself, as a stepping stone to using flake-parts.
 
 If you'd like to contribute to docs or add your own module, see [the Github README](https://github.com/flake-parts/community.flake.parts).


### PR DESCRIPTION
As background for understanding flake-parts

https://nixos.asia/en/nix-tutorial

Eventually we will have a flake-parts tutorial over there.