### PR TITLE
Add a docs flake module for re-use

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
             trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.garnix.io?priority=41 https://cache.nixos.org/
       - name: Build website
-        run: nix build
+        run: nix build .#docs
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
             trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.garnix.io?priority=41 https://cache.nixos.org/
       - name: Build website
-        run: nix build .#docs
+        run: nix build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ For further information, see [Emanote guide](https://emanote.srid.ca/guide). You
 
 - In `flake.nix`,
   - Add an flake input pointing to your module's repo
-  - Add your module input name to `modules` list
+  - Add your module input to the default value of `flake-parts-docs.modules` option.
 - In `doc/mods.md`, add a link to your module's documentation
-- Run `nix flake lock`
 - Run `nix run` to test the site locally. You can run `nix run .#preview` to preview the statically generated site.
 - Open a PR
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,43 @@ In order to best host your flake-parts module's documentation in this site, plea
 
 For further information, see [Emanote guide](https://emanote.srid.ca/guide). You can test your docs locally by running `nix run github:srid/emanote` under the `./doc` directory of your repository.
 
+## Building and previewing your local module docs
+
+Assuming your docs are in the `./doc` directory:
+
+1. Create a `doc/flake.nix` file with the following content, replacing `NAME` with your module name:
+
+    ```nix
+    {
+        inputs = {
+          cfp.url = "github:flake-parts/community.flake.parts/mod";
+          nixpkgs.follows = "cfp/nixpkgs";
+          flake-parts.follows = "cfp/flake-parts";
+        };
+
+        outputs = inputs:
+          inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+            systems = inputs.nixpkgs.lib.systems.flakeExposed;
+            imports = [
+                inputs.cfp.flakeModules.default
+            ];
+            perSystem = {
+              flake-parts-docs = {
+                enable = true;
+                modules."NAME" = {
+                  path = ./.;
+                  pathString = "./.";
+                };
+              };
+            };
+        };
+    }
+    ```
+1. Run `nix run ./doc` to live preview the docs
+1. Run `nix build ./doc` to build statically generated website of the docs
+
+This will give you a local copy of https://community.flake.parts/ but using your local module docs (overriding the upstream one if any).
+
 ## Publishing a module to this repository
 
 - In `flake.nix`,

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
-        inputs.emanote.flakeModule
         inputs.hercules-ci-effects.flakeModule
         (import ./nix/flake-module.nix { inherit inputs; })
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
         };
       };
       herculesCI.ciSystems = [ "x86_64-linux" ];
+      flake.flakeModules.default = import ./nix/flake-module.nix { inherit inputs; };
       perSystem = { config, self', pkgs, lib, system, ... }: {
         flake-parts-docs.enable = true;
         packages.default = self'.packages.docs;

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
       imports = [
         inputs.emanote.flakeModule
         inputs.hercules-ci-effects.flakeModule
+        ./nix/flake-module.nix
       ];
       hercules-ci.flake-update = {
         enable = true;
@@ -40,46 +41,22 @@
         };
       };
       herculesCI.ciSystems = [ "x86_64-linux" ];
-      perSystem = { config, self', pkgs, lib, system, ... }:
-        let
-          # Emanote sub-notebook layers for all modules
-          moduleDocLayers = builtins.map
-            (name: {
-              path = inputs.${name} + /doc;
-              mountPoint = name;
-            })
-            modules;
-          modules = [
-            "haskell-flake"
-            "nixos-flake"
-            "services-flake"
-            "process-compose-flake"
-            "mission-control"
-          ];
-        in
-        {
-          emanote = {
-            sites."default" = {
-              layers = [{ path = ./doc; pathString = "./doc"; }] ++ moduleDocLayers;
-              port = 5566;
-              prettyUrls = true;
-            };
-          };
-          apps.preview.program = pkgs.writeShellApplication {
-            name = "emanote-static-preview";
-            runtimeInputs = [ pkgs.static-web-server ];
-            text = ''
-              set -x
-              static-web-server -d ${self'.packages.default} -p ${builtins.toString (1 + config.emanote.sites.default.port)} "$@"
-            '';
-          };
-          devShells.default = pkgs.mkShell {
-            buildInputs = [
-              pkgs.nixpkgs-fmt
-              pkgs.just
-            ];
-          };
-          formatter = pkgs.nixpkgs-fmt;
+      perSystem = { config, self', pkgs, lib, system, ... }: {
+        apps.preview.program = pkgs.writeShellApplication {
+          name = "emanote-static-preview";
+          runtimeInputs = [ pkgs.static-web-server ];
+          text = ''
+            set -x
+            static-web-server -d ${self'.packages.default} -p ${builtins.toString (1 + config.emanote.sites.default.port)} "$@"
+          '';
         };
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nixpkgs-fmt
+            pkgs.just
+          ];
+        };
+        formatter = pkgs.nixpkgs-fmt;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -47,10 +47,13 @@
         apps.default = self'.apps.docs;
         apps.preview.program = pkgs.writeShellApplication {
           name = "emanote-static-preview";
+          meta.description = ''
+            Run a locally running preview of the statically generated docs.
+          '';
           runtimeInputs = [ pkgs.static-web-server ];
           text = ''
             set -x
-            static-web-server -d ${self'.packages.default} -p ${builtins.toString (1 + config.emanote.sites.default.port)} "$@"
+            static-web-server -d ${self'.packages.docs} -p ${builtins.toString (1 + config.emanote.sites.docs.port)} "$@"
           '';
         };
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       imports = [
         inputs.emanote.flakeModule
         inputs.hercules-ci-effects.flakeModule
-        ./nix/flake-module.nix
+        (import ./nix/flake-module.nix { inherit inputs; })
       ];
       hercules-ci.flake-update = {
         enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
       herculesCI.ciSystems = [ "x86_64-linux" ];
       perSystem = { config, self', pkgs, lib, system, ... }: {
         flake-parts-docs.enable = true;
+        packages.default = self'.packages.docs;
+        apps.default = self'.apps.docs;
         apps.preview.program = pkgs.writeShellApplication {
           name = "emanote-static-preview";
           runtimeInputs = [ pkgs.static-web-server ];

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
       };
       herculesCI.ciSystems = [ "x86_64-linux" ];
       perSystem = { config, self', pkgs, lib, system, ... }: {
+        flake-parts-docs.enable = true;
         apps.preview.program = pkgs.writeShellApplication {
           name = "emanote-static-preview";
           runtimeInputs = [ pkgs.static-web-server ];

--- a/flake.nix
+++ b/flake.nix
@@ -43,8 +43,6 @@
       flake.flakeModules.default = import ./nix/flake-module.nix { inherit inputs; };
       perSystem = { config, self', pkgs, lib, system, ... }: {
         flake-parts-docs.enable = true;
-        packages.default = self'.packages.docs;
-        apps.default = self'.apps.docs;
         apps.preview.program = pkgs.writeShellApplication {
           name = "emanote-static-preview";
           meta.description = ''
@@ -53,7 +51,7 @@
           runtimeInputs = [ pkgs.static-web-server ];
           text = ''
             set -x
-            static-web-server -d ${self'.packages.docs} -p ${builtins.toString (1 + config.emanote.sites.docs.port)} "$@"
+            static-web-server -d ${self'.packages.default} -p ${builtins.toString (1 + config.emanote.sites.default.port)} "$@"
           '';
         };
         devShells.default = pkgs.mkShell {

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -48,9 +48,8 @@ in
         };
 
         config = {
-          emanote = lib.mkIf config.flake-parts.enable {
-            # TODO: to "docs"
-            sites."default" = {
+          emanote = lib.mkIf config.flake-parts-docs.enable {
+            sites."docs" = {
               layers = lib.attrValues config.flake-parts-docs.modules;
               port = 5566;
               prettyUrls = true;

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -25,7 +25,6 @@ in
                     options = {
                       path = lib.mkOption {
                         type = types.path;
-                        default = current-flake.inputs.${name} + /doc;
                       };
                       pathString = lib.mkOption {
                         type = types.str;
@@ -39,11 +38,11 @@ in
                   }));
                   default = {
                     "".path = current-flake.inputs.self + /doc;
-                    "haskell-flake" = { };
-                    "nixos-flake" = { };
-                    "services-flake" = { };
-                    "process-compose-flake" = { };
-                    "mission-control" = { };
+                    "haskell-flake".path = current-flake.inputs."haskell-flake" + /doc;
+                    "nixos-flake".path = current-flake.inputs."nixos-flake" + /doc;
+                    "services-flake".path = current-flake.inputs."services-flake" + /doc;
+                    "process-compose-flake".path = current-flake.inputs."process-compose-flake" + /doc;
+                    "mission-control".path = current-flake.inputs."mission-control" + /doc;
                   };
                   description = "List of modules to generate documentation for";
                 };

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -35,6 +35,11 @@ in
             {
               options = {
                 enable = lib.mkEnableOption "Enable flake-parts-docs";
+                outputName = lib.mkOption {
+                  type = types.str;
+                  default = "default";
+                  description = "Name of the flake outputs";
+                };
                 defaultModules = lib.mkOption {
                   type = types.attrsOf docLayerModule;
                   default = {
@@ -60,7 +65,7 @@ in
         config = {
           emanote = lib.mkIf config.flake-parts-docs.enable {
             package = current-flake.inputs.emanote.packages.${system}.default;
-            sites."docs" = {
+            sites.${config.flake-parts-docs.outputName} = {
               layers = lib.attrValues config.flake-parts-docs.modules;
               port = 5566;
               prettyUrls = true;

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,5 +1,5 @@
-# A flake-parts module for building and running Emanote sites
-{ self, inputs, lib, flake-parts-lib, ... }:
+current-flake:
+{ self, lib, flake-parts-lib, ... }:
 
 let
   inherit (flake-parts-lib)
@@ -16,7 +16,7 @@ in
           # Emanote sub-notebook layers for all modules
           moduleDocLayers = builtins.map
             (name: {
-              path = inputs.${name} + /doc;
+              path = current-flake.inputs.${name} + /doc;
               mountPoint = name;
             })
             modules;

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -7,6 +7,21 @@ let
   inherit (lib)
     mkOption
     types;
+  docLayerModule = types.submodule ({ name, config, ... }: {
+    options = {
+      path = lib.mkOption {
+        type = types.path;
+      };
+      pathString = lib.mkOption {
+        type = types.str;
+        default = "${config.path}";
+      };
+      mountPoint = lib.mkOption {
+        type = types.str;
+        default = name;
+      };
+    };
+  });
 in
 {
   imports = [
@@ -20,22 +35,8 @@ in
             {
               options = {
                 enable = lib.mkEnableOption "Enable flake-parts-docs";
-                modules = lib.mkOption {
-                  type = types.attrsOf (types.submodule ({ name, config, ... }: {
-                    options = {
-                      path = lib.mkOption {
-                        type = types.path;
-                      };
-                      pathString = lib.mkOption {
-                        type = types.str;
-                        default = "${config.path}";
-                      };
-                      mountPoint = lib.mkOption {
-                        type = types.str;
-                        default = name;
-                      };
-                    };
-                  }));
+                defaultModules = lib.mkOption {
+                  type = types.attrsOf docLayerModule;
                   default = {
                     "".path = current-flake.inputs.self + /doc;
                     "haskell-flake".path = current-flake.inputs."haskell-flake" + /doc;
@@ -45,6 +46,12 @@ in
                     "mission-control".path = current-flake.inputs."mission-control" + /doc;
                   };
                   description = "List of modules to generate documentation for";
+                };
+                modules = lib.mkOption {
+                  type = types.attrsOf docLayerModule;
+                  default = { };
+                  apply = x: config.flake-parts-docs.defaultModules // x;
+                  description = "Modules to override on the default list";
                 };
               };
             };

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -14,7 +14,7 @@ in
   ];
   options = {
     perSystem = mkPerSystemOption
-      ({ config, self', inputs', pkgs, system, ... }: {
+      ({ config, self', pkgs, system, ... }: {
         options.flake-parts-docs = mkOption {
           type = types.submodule
             {
@@ -52,6 +52,7 @@ in
 
         config = {
           emanote = lib.mkIf config.flake-parts-docs.enable {
+            package = current-flake.inputs.emanote.packages.${system}.default;
             sites."docs" = {
               layers = lib.attrValues config.flake-parts-docs.modules;
               port = 5566;

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -25,6 +25,7 @@ in
                     options = {
                       path = lib.mkOption {
                         type = types.path;
+                        default = current-flake.inputs.${name} + /doc;
                       };
                       pathString = lib.mkOption {
                         type = types.str;
@@ -38,11 +39,11 @@ in
                   }));
                   default = {
                     "".path = current-flake.inputs.self + /doc;
-                    "haskell-flake".path = current-flake.inputs."haskell-flake" + /doc;
-                    "nixos-flake".path = current-flake.inputs."nixos-flake" + /doc;
-                    "services-flake".path = current-flake.inputs."services-flake" + /doc;
-                    "process-compose-flake".path = current-flake.inputs."process-compose-flake" + /doc;
-                    "mission-control".path = current-flake.inputs."mission-control" + /doc;
+                    "haskell-flake" = { };
+                    "nixos-flake" = { };
+                    "services-flake" = { };
+                    "process-compose-flake" = { };
+                    "mission-control" = { };
                   };
                   description = "List of modules to generate documentation for";
                 };

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -9,6 +9,9 @@ let
     types;
 in
 {
+  imports = [
+    current-flake.inputs.emanote.flakeModule
+  ];
   options = {
     perSystem = mkPerSystemOption
       ({ config, self', inputs', pkgs, system, ... }: {

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -1,0 +1,52 @@
+# A flake-parts module for building and running Emanote sites
+{ self, inputs, lib, flake-parts-lib, ... }:
+
+let
+  inherit (flake-parts-lib)
+    mkPerSystemOption;
+  inherit (lib)
+    mkOption
+    types;
+in
+{
+  options = {
+    perSystem = mkPerSystemOption
+      ({ config, self', inputs', pkgs, system, ... }:
+        let
+          # Emanote sub-notebook layers for all modules
+          moduleDocLayers = builtins.map
+            (name: {
+              path = inputs.${name} + /doc;
+              mountPoint = name;
+            })
+            modules;
+          modules = [
+            "haskell-flake"
+            "nixos-flake"
+            "services-flake"
+            "process-compose-flake"
+            "mission-control"
+          ];
+        in
+        {
+          options.flake-parts-docs = mkOption {
+            type = types.submodule {
+              options = {
+                enable = lib.mkEnableOption "Enable flake-parts-docs";
+              };
+            };
+          };
+
+          config = {
+            emanote = {
+              # TODO: to "docs"
+              sites."default" = {
+                layers = [{ path = ./doc; pathString = "./doc"; }] ++ moduleDocLayers;
+                port = 5566;
+                prettyUrls = true;
+              };
+            };
+          };
+        });
+  };
+}

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -11,42 +11,52 @@ in
 {
   options = {
     perSystem = mkPerSystemOption
-      ({ config, self', inputs', pkgs, system, ... }:
-        let
-          # Emanote sub-notebook layers for all modules
-          moduleDocLayers = builtins.map
-            (name: {
-              path = current-flake.inputs.${name} + /doc;
-              mountPoint = name;
-            })
-            modules;
-          modules = [
-            "haskell-flake"
-            "nixos-flake"
-            "services-flake"
-            "process-compose-flake"
-            "mission-control"
-          ];
-        in
-        {
-          options.flake-parts-docs = mkOption {
-            type = types.submodule {
+      ({ config, self', inputs', pkgs, system, ... }: {
+        options.flake-parts-docs = mkOption {
+          type = types.submodule
+            {
               options = {
                 enable = lib.mkEnableOption "Enable flake-parts-docs";
+                modules = lib.mkOption {
+                  type = types.attrsOf (types.submodule ({ name, config, ... }: {
+                    options = {
+                      path = lib.mkOption {
+                        type = types.path;
+                      };
+                      pathString = lib.mkOption {
+                        type = types.str;
+                        default = "${config.path}";
+                      };
+                      mountPoint = lib.mkOption {
+                        type = types.str;
+                        default = name;
+                      };
+                    };
+                  }));
+                  default = {
+                    "".path = current-flake.inputs.self + /doc;
+                    "haskell-flake".path = current-flake.inputs."haskell-flake" + /doc;
+                    "nixos-flake".path = current-flake.inputs."nixos-flake" + /doc;
+                    "services-flake".path = current-flake.inputs."services-flake" + /doc;
+                    "process-compose-flake".path = current-flake.inputs."process-compose-flake" + /doc;
+                    "mission-control".path = current-flake.inputs."mission-control" + /doc;
+                  };
+                  description = "List of modules to generate documentation for";
+                };
               };
             };
-          };
+        };
 
-          config = {
-            emanote = {
-              # TODO: to "docs"
-              sites."default" = {
-                layers = [{ path = ./doc; pathString = "./doc"; }] ++ moduleDocLayers;
-                port = 5566;
-                prettyUrls = true;
-              };
+        config = {
+          emanote = lib.mkIf config.flake-parts.enable {
+            # TODO: to "docs"
+            sites."default" = {
+              layers = lib.attrValues config.flake-parts-docs.modules;
+              port = 5566;
+              prettyUrls = true;
             };
           };
-        });
+        };
+      });
   };
 }


### PR DESCRIPTION
Towards 3rd bullet point in #6

The idea is to have downstream flake-parts modules to provide docs using a two line configuration in their flake.

- [x] Initial implementation
- [x] Test it one of the downstream flakes: https://github.com/srid/nixos-flake/pull/49
- [x] Docs
