### PR TITLE
Remove haskell-flake, redirect to haskell.nixos.asia

### DIFF
--- a/doc/haskell-flake.md
+++ b/doc/haskell-flake.md
@@ -1,0 +1,9 @@
+---
+page:
+  headHtml: |
+    <meta http-equiv="refresh" content="0; url=https://haskell.nixos.asia/">
+---
+
+# haskell-flake
+
+haskell-flake has moved to <https://haskell.nixos.asia/>.

--- a/doc/mods.md
+++ b/doc/mods.md
@@ -7,7 +7,7 @@ template:
 
 # Modules
 
-- [[haskell-flake]]#
+- [haskell-flake](https://haskell.nixos.asia/)
 - [[services-flake]]#
 - [[process-compose-flake]]#
 - [[mission-control]]#

--- a/flake.lock
+++ b/flake.lock
@@ -184,22 +184,6 @@
         "type": "github"
       }
     },
-    "haskell-flake_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1776030284,
-        "narHash": "sha256-RlhVw9N6HlepLj2oityi2k8+H3hWkFQHsUIouCCfIo0=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "f6eed3c0c2ab8abb9fccd058092eba0a399513dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
     "heist-extra": {
       "flake": false,
       "locked": {
@@ -338,7 +322,6 @@
           "emanote",
           "flake-parts"
         ],
-        "haskell-flake": "haskell-flake_2",
         "hercules-ci-effects": "hercules-ci-effects",
         "mission-control": "mission-control",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,6 @@
     hercules-ci-effects.url = "github:hercules-ci/hercules-ci-effects";
 
     # Individual flake-parts modules go here
-    haskell-flake.url = "github:srid/haskell-flake";
-    haskell-flake.flake = false;
     services-flake.url = "github:juspay/services-flake";
     services-flake.flake = false;
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -44,7 +44,6 @@ in
                   type = types.attrsOf docLayerModule;
                   default = {
                     "".path = current-flake.inputs.self + /doc;
-                    "haskell-flake".path = current-flake.inputs."haskell-flake" + /doc;
                     "services-flake".path = current-flake.inputs."services-flake" + /doc;
                     "process-compose-flake".path = current-flake.inputs."process-compose-flake" + /doc;
                     "mission-control".path = current-flake.inputs."mission-control" + /doc;


### PR DESCRIPTION
## Summary
- Remove haskell-flake flake input and doc layer
- Add a redirect page at `/haskell-flake` so existing links redirect to https://haskell.nixos.asia/
- Update modules listing to link externally to the new home

🤖 Generated with [Claude Code](https://claude.com/claude-code)